### PR TITLE
fix: Resolve critical runtime bugs across UI, helpers, and Terraform

### DIFF
--- a/src/AI_student.py
+++ b/src/AI_student.py
@@ -44,7 +44,7 @@ def main():
   if st.session_state.valid_config:
     main_ui.display_page(state_manager)
   else:
-    settings_ui.display_page(state_manager)
+    settings_ui.display_page()
 
 
 if __name__ == "__main__":

--- a/src/frontend/main_ui.py
+++ b/src/frontend/main_ui.py
@@ -43,7 +43,7 @@ from utils import llm_helper
 from utils.event_helper import session_state_manager
 
 logging.getLogger().setLevel(logging.DEBUG)
-logger = logging.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 _SCHEMA_EVALUATIONS = {}
 
@@ -478,6 +478,9 @@ def _sample_keywords(state_manager):
 
 
 def _score_keywords(state_manager):
+  if state_manager.get("scored_keywords", None):
+    return
+
   formatted_facts = models.format_scoring_fragment(
       state_manager.get("evaluations") or _SCHEMA_EVALUATIONS
   )
@@ -488,36 +491,34 @@ def _score_keywords(state_manager):
   keywords_to_score = []
 
   for _, row in keywords.iterrows():
-      is_positive_in_other_adgroup = False
-      if not positive_keywords.empty:
-          conflicting_positives = positive_keywords[
-              (positive_keywords["keyword"] == row["keyword"]) &
-              (positive_keywords["campaign_id"] == row["campaign_id"]) &
-              (positive_keywords["adgroup_id"] != row["adgroup_id"])
-          ]
-          if not conflicting_positives.empty:
-              is_positive_in_other_adgroup = True
+    is_positive_in_other_adgroup = False
+    if not positive_keywords.empty:
+      conflicting_positives = positive_keywords[
+          (positive_keywords["keyword"] == row["keyword"]) &
+          (positive_keywords["campaign_id"] == row["campaign_id"]) &
+          (positive_keywords["adgroup_id"] != row["adgroup_id"])
+      ]
+      if not conflicting_positives.empty:
+        is_positive_in_other_adgroup = True
 
-      if is_positive_in_other_adgroup:
-          pre_scored_keywords.append(models.KeywordEvaluation(
-              keyword=row["keyword"],
-              decision=models.ScoreDecision.KEEP,
-              reason="This keyword is positive in another adgroup in the same "
-              "campaign."
-          ))
-      else:
-          keywords_to_score.append(row["keyword"])
+    if is_positive_in_other_adgroup:
+      pre_scored_keywords.append(models.KeywordEvaluation(
+          keyword=row["keyword"],
+          decision=models.ScoreDecision.KEEP,
+          reason="This keyword is positive in another adgroup in the same "
+          "campaign."
+      ))
+    else:
+      keywords_to_score.append(row["keyword"])
 
-  formatted_keywords = json.dumps(
-      [keyword.strip("'\"") for keyword in keywords_to_score],
-      ensure_ascii=False,
-  )
-  prompt = _create_prompt()
-  scoring_llm = llm_helper.select_llm(state_manager.get("config"))
-
-  scored_keywords = state_manager.get("scored_keywords", None)
-  if not scored_keywords:
-    with st.spinner("Scoring a new batch of keywords..."):
+  with st.spinner("Scoring a new batch of keywords..."):
+    if keywords_to_score:
+      formatted_keywords = json.dumps(
+          [keyword.strip("'\"") for keyword in keywords_to_score],
+          ensure_ascii=False,
+      )
+      prompt = _create_prompt()
+      scoring_llm = llm_helper.select_llm(state_manager.get("config"))
       llm_chain = chains.LLMChain(prompt=prompt, llm=scoring_llm, verbose=True)
       llm_scored_keywords_raw = llm_chain.run({
           "company_segment": "\n\n".join(
@@ -531,19 +532,15 @@ def _score_keywords(state_manager):
           ),
           "facts_segment": formatted_facts,
           "keywords_segment": formatted_keywords,
-          "decision_allowed_values": ", ".join(
-              x.value for x in models.ScoreDecision
-          ),
-          "batch_size": state_manager.get("batch_size"),
       })
-
       llm_scored_keywords = models.parse_scoring_response(
           llm_scored_keywords_raw
       )
+    else:
+      llm_scored_keywords = []
 
-      # Combine pre-scored and LLM-scored keywords
-      all_scored_keywords = pre_scored_keywords + llm_scored_keywords
-      state_manager.set("scored_keywords", all_scored_keywords)
+    all_scored_keywords = pre_scored_keywords + llm_scored_keywords
+    state_manager.set("scored_keywords", all_scored_keywords)
 
 
 def _create_prompt():
@@ -584,8 +581,6 @@ def _create_prompt():
           "company_segment",
           "facts_segment",
           "keywords_segment",
-          "decision_allowed_values",
-          "batch_size",
       ],
   )
   return prompt
@@ -767,10 +762,6 @@ def _process_remaining_keywords(state_manager):
         ),
         "facts_segment": formatted_facts,
         "keywords_segment": formatted_keywords,
-        "decision_allowed_values": ", ".join(
-            x.value for x in models.ScoreDecision
-        ),
-        "batch_size": state_manager.get("batch_size"),
     })
 
     try:
@@ -797,7 +788,7 @@ def _download_results(state_manager):
   if state_manager.get("scoring_kws_evals", None):
     _prepare_and_display_downloads(state_manager)
   _handle_stop_training(state_manager)
-  _display_consolidated_download(state_manager)
+  _display_consolidated_download()
 
 
 def _format_customer_id(cid: int) -> str:

--- a/src/frontend/models.py
+++ b/src/frontend/models.py
@@ -23,7 +23,6 @@ from typing import Optional, Any, Dict, List
 import pandas as pd
 import requests
 import streamlit as st
-import streamlit.components.v1 as components
 import yaml
 from bs4 import BeautifulSoup
 from langchain.chains import summarize
@@ -31,7 +30,6 @@ from langchain.docstore.document import Document
 from langchain.llms.base import LLM
 from langchain.prompts import PromptTemplate
 from langchain.text_splitter import CharacterTextSplitter
-from requests.exceptions import HTTPError, SSLError
 
 logger = logging.getLogger(__name__)
 
@@ -85,72 +83,26 @@ def fetch_landing_page_text(url: str) -> List[Document]:
   Returns:
   List[Document]: A list of Documents containing the text from the landing page.
   """
-  content = ""
-  try:
-    # Since we are making requests from a datacenter,
-    # the following request sometimes get rejected.
-    #
-    # To avoid this, we are mimicking an actual browser
-    headers = {
-        "User-Agent": (
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"
-            " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0"
-            " Safari/537.36"
-        ),
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
-        "Accept-Language": "en-US,en;q=0.9",
-        "Connection": "keep-alive",
-        "DNT": "1",  # Do Not Track Request Header
-        "Upgrade-Insecure-Requests": "1",
-    }
-    response = requests.get(url, headers=headers)
-    response.raise_for_status()
+  headers = {
+      "User-Agent": (
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"
+          " AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0"
+          " Safari/537.36"
+      ),
+      "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+      "Accept-Language": "en-US,en;q=0.9",
+      "Connection": "keep-alive",
+      "DNT": "1",
+      "Upgrade-Insecure-Requests": "1",
+  }
+  response = requests.get(url, headers=headers, timeout=15)
+  response.raise_for_status()
 
-    text_content = response.text
-    logger.info(text_content)
-    soup = BeautifulSoup(text_content, features="html.parser")
-    texts = soup.find_all(text=True)
-    content = "\n".join(
-        str(t).strip() for t in texts if t.parent.name not in _HTML_EXCLUDE_TAGS
-    ).strip()
-  except (HTTPError, SSLError) as err:
-    # Fallback to Client-Side Fetch
-    st.warning("Server-side fetch failed. Trying client-side fetch...")
-
-    js_code = """
-            <script>
-            const url = window.Streamlit.getUrlParams()['url'];  
-
-            fetch(url)
-                .then(response => {
-                    if (!response.ok) {
-                        throw new Error(`HTTP error: ${response.status}`);
-                    }
-                    return response.text();
-                })
-                .then(html => {
-                    const parser = new DOMParser();
-                    const doc = parser.parseFromString(html, 'text/html');
-                    const textContent = Array.from(doc.body.querySelectorAll('*')) // Select all elements
-                        .filter(el => !_HTML_EXCLUDE_TAGS.includes(el.tagName.toLowerCase())) 
-                        .map(el => el.textContent.trim())
-                        .join('\\n');
-
-                    window.Streamlit.setComponentValue(textContent);
-                })
-                .catch(error => {
-                    window.Streamlit.setComponentValue('Error: ' + error.message);
-                });
-            </script>
-        """
-
-    component_value = components.html(js_code, height=0, width=0)
-
-    if component_value.text.startswith("Error:"):
-      st.error(component_value)
-      st.stop()
-
-    content = component_value
+  soup = BeautifulSoup(response.text, features="html.parser")
+  texts = soup.find_all(string=True)
+  content = "\n".join(
+      str(t).strip() for t in texts if t.parent.name not in _HTML_EXCLUDE_TAGS
+  ).strip()
 
   # Splits into multiple documents to fit into LLM context.
   text_splitter = CharacterTextSplitter()
@@ -345,10 +297,10 @@ def parse_scoring_response(response: str) -> List[KeywordEvaluation]:
     return []
 
   try:
-    data = yaml.safe_load(response)
+    yaml.safe_load(response)
   except yaml.parser.ParserError as e:
     logger.error(f"Error parsing YAML data: {e}")
-    logger.error(f"Original Content: {data}")
+    logger.error(f"Original Content: {response}")
     return []
 
   outputs = []

--- a/src/frontend/models_test.py
+++ b/src/frontend/models_test.py
@@ -15,9 +15,19 @@
 import collections
 import unittest
 
-import models
+from frontend import models
 
-EXPECTED_RESPONSE = """
+# format_scoring_fragment rewrites "reason:" to "reason::" by design.
+EXPECTED_FRAGMENT = (
+    "- keyword: keyword1\n"
+    "  reason:: Reason for keeping keyword1\n"
+    "  decision: KEEP\n"
+    "- keyword: keyword2\n"
+    "  reason:: Reason for removing keyword2\n"
+    "  decision: REMOVE\n"
+)
+
+LLM_RESPONSE = """
 - keyword: keyword1
   reason: Reason for keeping keyword1
   decision: KEEP
@@ -48,9 +58,8 @@ class ModelsTest(unittest.TestCase):
             ),
         ),
     ])
-    expected_fragment = EXPECTED_RESPONSE
     self.assertEqual(
-        models.format_scoring_fragment(evaluations), expected_fragment
+        models.format_scoring_fragment(evaluations), EXPECTED_FRAGMENT
     )
 
   def test_parse_scoring_response(self):
@@ -67,7 +76,7 @@ class ModelsTest(unittest.TestCase):
         ),
     ]
     self.assertEqual(
-        models.parse_scoring_response(EXPECTED_RESPONSE),
+        models.parse_scoring_response(LLM_RESPONSE),
         expected_evaluations,
     )
 

--- a/src/utils/auth.py
+++ b/src/utils/auth.py
@@ -90,7 +90,6 @@ def get_access_token():
 
 
 def get_credentials(config: Dict[str, Any]):
-  creds = None
   user_info = {
       "client_id": config["client_id"],
       "refresh_token": config["refresh_token"],
@@ -103,10 +102,11 @@ def get_credentials(config: Dict[str, Any]):
     try:
       creds.refresh(Request())
     except Exception as error:
-      if "invalid_scope" in error.args[0]:
-        creds = None
+      if error.args and "invalid_scope" in error.args[0]:
+        return None
+      raise
 
-  if not creds.valid:
-    creds = None
+  if creds is None or not creds.valid:
+    return None
 
   return creds

--- a/src/utils/data_helper.py
+++ b/src/utils/data_helper.py
@@ -14,6 +14,7 @@
 
 import pandas as pd
 import streamlit as st
+from google.api_core import exceptions
 
 from utils.keyword_helper import KeywordHelper, Customer
 
@@ -32,11 +33,11 @@ def load_keywords(selected_customers: list) -> pd.DataFrame:
   Returns:
   pd.DataFrame: A DataFrame containing the negative keywords along with additional information.
   """
-  kw_helper = KeywordHelper(st.session_state.config)
-
-  if not kw_helper:
-    st.error("An internal error occurred. Could not load KeywordHelper.")
-    return
+  try:
+    kw_helper = KeywordHelper(st.session_state.config)
+  except exceptions.GoogleAPIError as e:
+    st.error(f"Could not initialize the Google Ads client: {e}")
+    st.stop()
 
   with st.spinner(
       text="Loading negative keywords... This may take a few minutes"
@@ -124,10 +125,11 @@ def load_customers(customer_ids: list[str]) -> pd.DataFrame:
   Returns:
     A pandas DataFrame containing the customer data.
   """
-  kw_helper = KeywordHelper(st.session_state.config)
-  if not kw_helper:
-    st.error("An internal error occurred. Could not load KeywordHelper.")
-    return
+  try:
+    kw_helper = KeywordHelper(st.session_state.config)
+  except exceptions.GoogleAPIError as e:
+    st.error(f"Could not initialize the Google Ads client: {e}")
+    st.stop()
 
   with st.spinner(text="Loading customers under MCC, please wait..."):
     customers_report = kw_helper.get_customers(customer_ids)

--- a/src/utils/keyword_helper.py
+++ b/src/utils/keyword_helper.py
@@ -140,7 +140,6 @@ class Keyword:
 
 class KeywordHelper:
   def __init__(self, config: Config):
-    config = Config
     # Expand the mcc account to child accounts to initialize the report fetcher
     googleads_api_client = GoogleAdsApiClient(
         config_dict={
@@ -153,13 +152,10 @@ class KeywordHelper:
         },
         version=_GOOGLE_ADS_API_VERSION,
     )
-    try:
-      customer_ids = get_customer_ids(
-          googleads_api_client, config.login_customer_id
-      )
-      self.report_fetcher = AdsReportFetcher(googleads_api_client, customer_ids)
-    except exceptions.InternalServerError as e:
-      return None
+    customer_ids = get_customer_ids(
+        googleads_api_client, config.login_customer_id
+    )
+    self.report_fetcher = AdsReportFetcher(googleads_api_client, customer_ids)
 
   def get_customers(self, customer_ids: list[str]) -> GaarfReport:
     """Loads customer data for a given list of IDs.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -120,7 +120,7 @@ resource "google_cloud_run_v2_service" "default" {
 
   template {
     containers {
-      image = "gcr.io/${var.project_id}/negatives:v1"
+      image = "us-central1-docker.pkg.dev/${var.project_id}/negatives/negatives:v1"
 
       env {
         name  = "port"


### PR DESCRIPTION
- AI_student.py / main_ui.py: drop stale state_manager arg from settings_ui.display_page and _display_consolidated_download calls that no longer accept one
- keyword_helper.py: remove `config = Config` line that shadowed the instance with the class; remove `return None` from __init__ and let GoogleAPIError propagate to data_helper, which now handles it via st.error/st.stop
- main_ui.py: replace logging.Logger(__name__) (detached, no handlers) with logging.getLogger; drop unused decision_allowed_values and batch_size from PromptTemplate.input_variables and chain.run calls; early-return in _score_keywords when cached and skip the LLM call when nothing needs scoring
- models.py: fix UnboundLocalError in YAML parser error path; replace deprecated find_all(text=True) with string=True; remove broken JS fallback in fetch_landing_page_text and add a request timeout
- auth.py: guard get_credentials against AttributeError when creds is None; guard error.args indexing; re-raise non-invalid_scope refresh errors instead of swallowing
- models_test.py: import via \`from frontend import models\`; split expected output between the fragment formatter (with \`reason::\`) and the parse_scoring_response input
- terraform/main.tf: point Cloud Run at the Artifact Registry URL the README actually pushes to (us-central1-docker.pkg.dev) instead of the unused gcr.io path